### PR TITLE
Fix test7

### DIFF
--- a/emirdrp/recipes/aiv/common.py
+++ b/emirdrp/recipes/aiv/common.py
@@ -472,6 +472,7 @@ def pinhole_char2(
 def shape_of_slices(tup_of_s):
     return tuple(m.stop - m.start for m in tup_of_s)
 
+
 def normalize(data):
     b = data.max()
     a = data.min()
@@ -481,6 +482,17 @@ def normalize(data):
     else:
         data_22 = data - b
     return data_22
+
+
+def normalize_raw(arr):
+    """Rescale float image between -1, 1"""
+
+    # FIXME: use other limits acording to original arr.dtype
+    # This applies only to uint16 images
+    # As images where positive, the range is 0,1
+    b = 65535.0
+
+    return numpy.clip(data / b, 0.0, 1.0)
 
 
 def get_dtur_from_header(hdr):

--- a/emirdrp/recipes/aiv/slits.py
+++ b/emirdrp/recipes/aiv/slits.py
@@ -43,7 +43,7 @@ from emirdrp.requirements import MasterSkyRequirement
 
 from .flows import basic_processing_with_combination
 from .flows import init_filters_bdfs
-from .common import normalize, char_slit
+from .common import normalize_raw, char_slit
 from .common import get_dtur_from_header
 
 _logger = logging.getLogger('numina.recipes.emir')
@@ -109,7 +109,7 @@ class TestSlitDetectionRecipe(EmirRecipe):
         data2 = median_filter(data1, size=median_filter_size)
 
         # Grey level image
-        img_grey = normalize(data2)
+        img_grey = normalize_raw(data2)
 
         # Find edges with canny
         _logger.debug('Find edges with canny, sigma %d', canny_sigma)

--- a/emirdrp/recipes/aiv/slits.py
+++ b/emirdrp/recipes/aiv/slits.py
@@ -17,7 +17,7 @@
 # along with PyEmir.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-'''Recipe to detect slits in the AIV mask'''
+"""Recipe to detect slits in the AIV mask"""
 
 from __future__ import division
 
@@ -32,7 +32,7 @@ from skimage.filter import canny
 from numina.core import Product, Parameter
 from numina.core.requirements import ObservationResultRequirement
 from numina.core import RecipeError
-#
+
 from emirdrp.core import EmirRecipe
 from emirdrp.products import DataFrameType
 from numina.core.products import ArrayType
@@ -103,8 +103,7 @@ class TestSlitDetectionRecipe(EmirRecipe):
         # First, prefilter with median
         median_filter_size = rinput.median_filter_size
         canny_sigma = rinput.canny_sigma
-        
-        
+
         _logger.debug('Median filter with box %d', median_filter_size)
         data2 = median_filter(data1, size=median_filter_size)
 
@@ -113,7 +112,10 @@ class TestSlitDetectionRecipe(EmirRecipe):
 
         # Find edges with canny
         _logger.debug('Find edges with canny, sigma %d', canny_sigma)
-        edges = canny(img_grey, sigma=canny_sigma)
+        _logger.debug('Find edges with canny, high threshold %d', canny_sigma)
+        edges = canny(img_grey, sigma=canny_sigma,
+                      high_threshold=0.1, # approx 6500 counts
+                      low_threshold=0.05)
         
         # Fill edges
         _logger.debug('Fill holes')
@@ -200,14 +202,13 @@ class TestSlitMaskDetectionRecipe(EmirRecipe):
         canny_sigma = rinput.canny_sigma
         obj_min_size = rinput.obj_min_size
         obj_max_size = rinput.obj_max_size
-        
-        
+
         data1 = hdulist[0].data
         _logger.debug('Median filter with box %d', median_filter_size)
         data2 = median_filter(data1, size=median_filter_size)
 
         # Grey level image
-        img_grey = normalize(data2)
+        img_grey = normalize_raw(data2)
 
         # Find edges with canny
         _logger.debug('Find edges with canny, sigma %d', canny_sigma)


### PR DESCRIPTION
scikit image converts integer images to float using the range [-1,1] When the original data is unsigned, skimage uses the range [0,1]. This PR uses a new function that scales the processed images into [0,1], assigning 1 to 2^16-1.

With this new scaling, we can use the threshold parameters in canny. We set high_threshold to 0.1, roughly 6500 counts. Borders with less than these counts will not be detected.